### PR TITLE
Update CPPickerView.h

### DIFF
--- a/PickerView/CPPickerView/CPPickerView.h
+++ b/PickerView/CPPickerView/CPPickerView.h
@@ -55,8 +55,8 @@
 }
 
 // Datasource and delegate
-@property (nonatomic, unsafe_unretained) id <CPPickerViewDataSource> dataSource;
-@property (nonatomic, unsafe_unretained) id <CPPickerViewDelegate> delegate;
+@property (nonatomic, unsafe_unretained) IBOutlet id <CPPickerViewDataSource> dataSource;
+@property (nonatomic, unsafe_unretained) IBOutlet id <CPPickerViewDelegate> delegate;
 // Views
 @property (nonatomic, strong) UIScrollView *contentView;
 // Current status


### PR DESCRIPTION
Marking delegates and datasources with IBOutlet so they can be assigned from InterfaceBuilder.

Consideration - should contentView be public?  Can it be changeable after the picker is created?
